### PR TITLE
Fix: Add missing placeholder to sprintf()

### DIFF
--- a/src/MailService.php
+++ b/src/MailService.php
@@ -8,6 +8,6 @@ class MailService
     {
         echo sprintf("Sending mail with subject '%s' to %s... \n", $mail->getSubject(), $mail->getRecipientAddress());
         sleep(2);
-        echo sprintf("Mail sent. \n", $mail->getRecipientAddress());
+        echo sprintf("Mail sent to %s. \n", $mail->getRecipientAddress());
     }
 }


### PR DESCRIPTION
This PR

* [x] adds an otherwise missing placeholder to a call to `sprintf()`

💁‍♂️ Running

```
$ phpstan analyse --level=7 src
```

yields

```
 7/7 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ---------------------------------------------------------
  Line   src/MailService.php
 ------ ---------------------------------------------------------
  11     Call to sprintf contains 0 placeholders, 1 value given.
 ------ ---------------------------------------------------------


 [ERROR] Found 1 error

```