### PR TITLE
Enhancement: Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - .:/var/www/html
       - ./docker/checkout.conf:/etc/nginx/conf.d/default.conf
     ports:
-        - 8080:80
+      - 8080:80
   php:
     build: .
     volumes:


### PR DESCRIPTION
This PR

* [x] adds an `.editorconfig`
* [x] consistently indents `docker-compose.yml` with 2 spaces

💁‍♂️ For reference, see https://editorconfig.org.